### PR TITLE
core_kernel v0.14 deprecates unix module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,8 @@ clean:
 	@dune clean
 
 coverage: clean
-	@BISECT_ENABLE=YES dune runtest
-	@bisect-ppx-report -I _build/default/ -html _coverage/ \
-	  `find . -name 'bisect*.out'`
+	@BISECT_ENABLE=yes dune runtest
+	@bisect-ppx-report send-to Coveralls
 
 install: build
 	@dune install

--- a/dune-project
+++ b/dune-project
@@ -21,20 +21,30 @@
  (name sentry)
  (synopsis "Unofficial Async Sentry error monitoring client")
  (description
-  "Sentry is an unofficial Async OCaml client for the Sentry error reporting.")
+   "Sentry is an unofficial Async OCaml client for the Sentry error reporting.")
  (depends
-  (async_unix (>= v0.13.0))
+  (core
+   (>= v0.13.0))
   atdgen
-  (bisect_ppx (and :dev (>= 2.0.0)))
-  (cohttp (>= 2.0.0))
-  (cohttp-async (>= 2.0.0))
-  (dune (>= 1.11.0))
-  (hex (>= 1.2.0))
+  (bisect_ppx
+   (and
+    :dev
+    (>= 2.0.0)))
+  (cohttp
+   (>= 2.0.0))
+  (cohttp-async
+   (>= 2.0.0))
+  (dune
+   (>= 1.11.0))
+  (hex
+   (>= 1.2.0))
   json-derivers
   ppx_jane
-  (ocaml (>= 4.08.0))
+  (ocaml
+   (>= 4.08.0))
   re2
-  (sexplib (>= v0.13.0))
+  (sexplib
+   (>= v0.13.0))
   uuidm
   uri
   yojson))

--- a/sentry.opam
+++ b/sentry.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/brendanlong/sentry-ocaml"
 doc: "https://brendanlong.github.io/sentry-ocaml"
 bug-reports: "https://github.com/brendanlong/sentry-ocaml/issues"
 depends: [
-  "async_unix" {>= "v0.13.0"}
+  "core" {>= "v0.13.0"}
   "atdgen"
   "bisect_ppx" {dev & >= "2.0.0"}
   "cohttp" {>= "2.0.0"}

--- a/src/context.ml
+++ b/src/context.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+open Core
 
 type t =
   { mutable environment : string option
@@ -38,11 +38,11 @@ let add_breadcrumb crumb t =
   Queue.enqueue t.breadcrumbs crumb
 ;;
 
-let default_environment = Sys.getenv_opt "SENTRY_ENVIRONMENT"
-let default_release = Sys.getenv_opt "SENTRY_RELEASE"
+let default_environment = Sys.getenv "SENTRY_ENVIRONMENT"
+let default_release = Sys.getenv "SENTRY_RELEASE"
 
 let default_server_name =
-  match Sys.getenv_opt "SENTRY_NAME" with
+  match Sys.getenv "SENTRY_NAME" with
   | None -> Some (Unix.gethostname ())
   | value -> value
 ;;

--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,7 @@
 
 let preprocess =
   match Sys.getenv "BISECT_ENABLE" with
-  | "yes" -> "bisect_ppx --exclusions src/.exclude"
+  | "yes" -> "bisect_ppx"
   | _ -> ""
   | exception Not_found -> ""
 
@@ -23,8 +23,7 @@ let () = Jbuild_plugin.V1.send @@ {|
  (inline_tests
   (flags (-verbose)))
  (preprocess
-  (pps ppx_jane |} ^ preprocess ^ {|))
- (preprocessor_deps .exclude))
+  (pps ppx_jane |} ^ preprocess ^ {|)))
 
 (rule
  (targets payloads_j.ml payloads_j.mli)


### PR DESCRIPTION
Core_kernel v0.14 deprecated the Unix module. The recommended options
are to use Core.Unix with Core_kernel.Caml_unix as a fallback. We pull
in unix dependencies for other reasons in sentry, so using Core seems
like a better option.

Release notes for v0.14.0 https://discuss.ocaml.org/t/ann-v0-14-release-of-jane-street-packages/5893