### PR TITLE
Update to use Yojson 1.6 `t` type

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -47,4 +47,5 @@
    (>= v0.13.0))
   uuidm
   uri
-  yojson))
+  (yojson
+   (>= 1.6.0))))

--- a/sentry.opam
+++ b/sentry.opam
@@ -24,7 +24,7 @@ depends: [
   "sexplib" {>= "v0.13.0"}
   "uuidm"
   "uri"
-  "yojson"
+  "yojson" {>= "1.6.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/src/json.ml
+++ b/src/json.ml
@@ -1,5 +1,5 @@
-type t = Yojson.Basic.json
+type t = Yojson.Basic.t
 
-let sexp_of_t (t : Yojson.Basic.json) =
+let sexp_of_t (t : Yojson.Basic.t) =
   Json_derivers.Yojson.sexp_of_t (t :> Json_derivers.Yojson.t)
 ;;

--- a/src/json.mli
+++ b/src/json.mli
@@ -1,2 +1,2 @@
-(** Wrapper for Yojson.Basic.json with sexp_of *)
-type t = Yojson.Basic.json [@@deriving sexp_of]
+(** Wrapper for Yojson.Basic.t with sexp_of *)
+type t = Yojson.Basic.t [@@deriving sexp_of]

--- a/src/payloads.atd
+++ b/src/payloads.atd
@@ -1,4 +1,4 @@
-type json <ocaml module="Yojson.Basic"> = abstract
+type t <ocaml module="Yojson.Basic"> = abstract
 
 type capped_string_4k = string wrap <ocaml module="Capped_string_4k">
 type capped_string_512 = string wrap <ocaml module="Capped_string_512">
@@ -59,7 +59,7 @@ type breadcrumb =
   { timestamp : datetime
   ; ?type_ <json name="type"> : capped_string_512 nullable
   ; ?message : capped_string_512 nullable
-  ; ?data : (capped_string_512 *  json) list <json repr="object"> nullable
+  ; ?data : (capped_string_512 *  t) list <json repr="object"> nullable
   ; ?category : capped_string_512 nullable
   ; ?level : capped_string_512 nullable }
 
@@ -76,7 +76,7 @@ type event =
   ; ?tags : (capped_string_512 * capped_string_512) list <json repr="object"> nullable
   ; ?environment : capped_string_512 nullable
   ; ?modules : (capped_string_512 * capped_string_512) list <json repr="object"> nullable
-  ; ?extra : (capped_string_512 * json) list <json repr="object"> nullable
+  ; ?extra : (capped_string_512 * t) list <json repr="object"> nullable
   ; ?fingerprint : capped_string_512 list nullable
   ; ?exception_ <json name="exception"> : exception_ nullable
   ; ?message <json name="sentry.interfaces.Message"> : message nullable


### PR DESCRIPTION
This makes the code compatible with Yojson 2.0+

See https://github.com/ocaml/opam-repository/pull/21973